### PR TITLE
Add missing booking types to financial mutation

### DIFF
--- a/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
+++ b/src/Picqer/Financials/Moneybird/Entities/FinancialMutation.php
@@ -24,10 +24,15 @@ class FinancialMutation extends Model
      */
     private static $allowedBookingTypesToLinkToFinancialMutation = [
         'Document',
+        'ExternalSalesInvoice',
         'LedgerAccount',
         'NewPurchaseInvoice',
         'NewReceipt',
+        'Payment',
+        'PaymentTransaction',
         'PaymentTransactionBatch',
+        'PurchaseTransaction',
+        'PurchaseTransactionBatch',
         'SalesInvoice',
     ];
 


### PR DESCRIPTION
Fix: Added ExternalSalesInvoice, Payment, PaymentTransaction, PurchaseTransaction and PurchaseTransactionBatch as allowed booking types to link to.